### PR TITLE
Fix sensor/binary_sensor schema: avoid passing None to schema()

### DIFF
--- a/components/opentherm/binary_sensor/__init__.py
+++ b/components/opentherm/binary_sensor/__init__.py
@@ -9,13 +9,12 @@ COMPONENT_TYPE = const.BINARY_SENSOR
 
 
 def get_entity_validation_schema(entity: schema.BinarySensorSchema) -> cv.Schema:
-    return binary_sensor.binary_sensor_schema(
-        device_class=(
-            entity.device_class
-            or binary_sensor._UNDEF  # pylint: disable=protected-access
-        ),
-        icon=(entity.icon or binary_sensor._UNDEF),  # pylint: disable=protected-access
-    )
+    kwargs = {}
+    if entity.device_class is not None:
+        kwargs["device_class"] = entity.device_class
+    if entity.icon is not None:
+        kwargs["icon"] = entity.icon
+    return binary_sensor.binary_sensor_schema(**kwargs)
 
 
 CONFIG_SCHEMA = validate.create_component_schema(

--- a/components/opentherm/sensor/__init__.py
+++ b/components/opentherm/sensor/__init__.py
@@ -21,15 +21,24 @@ MSG_DATA_TYPES = {
 
 
 def get_entity_validation_schema(entity: schema.SensorSchema) -> cv.Schema:
-    return sensor.sensor_schema(
-        unit_of_measurement=entity.unit_of_measurement
-        or sensor._UNDEF,  # pylint: disable=protected-access
-        accuracy_decimals=entity.accuracy_decimals,
-        device_class=entity.device_class
-        or sensor._UNDEF,  # pylint: disable=protected-access
-        icon=entity.icon or sensor._UNDEF,  # pylint: disable=protected-access
-        state_class=entity.state_class,
-    ).extend(
+    kwargs = {}
+
+    if entity.unit_of_measurement is not None:
+        kwargs["unit_of_measurement"] = entity.unit_of_measurement
+
+    if entity.accuracy_decimals is not None:
+        kwargs["accuracy_decimals"] = entity.accuracy_decimals
+
+    if entity.device_class is not None:
+        kwargs["device_class"] = entity.device_class
+
+    if entity.icon is not None:
+        kwargs["icon"] = entity.icon
+
+    if entity.state_class is not None:
+        kwargs["state_class"] = entity.state_class
+
+    return sensor.sensor_schema(**kwargs).extend(
         {
             cv.Optional(const.CONF_DATA_TYPE): cv.one_of(*MSG_DATA_TYPES),
         }


### PR DESCRIPTION
Fix: avoid passing None to sensor_schema and binary_sensor_schema
This PR fixes a configuration validation error caused by passing None values to sensor_schema() and binary_sensor_schema() in ESPHome 2025.5+.

Problem
When optional parameters like icon, device_class, or unit_of_measurement are not set in YAML, None was passed to the schema constructors, resulting in the error:

Must be string, got <class 'NoneType'>. did you forget putting quotes around the value?
Solution
Updated the code to pass these parameters only if they are not None, ensuring compatibility with stricter schema validation in newer ESPHome versions.

Testing
Tested locally with ESPHome 2025.5.1 using external components. Configuration now validates and compiles correctly.