### PR TITLE
module 'esphome.components.binary_sensor' has no attribute '_UNDEF'

### DIFF
--- a/components/opentherm/HardwareSerial.cpp
+++ b/components/opentherm/HardwareSerial.cpp
@@ -4,7 +4,7 @@
 
 #include "HardwareSerial.h"
 
-#define ECHO_UART_PORT_NUM (uart_port_t)(1)
+#define ECHO_UART_PORT_NUM (UART_NUM_1)
 
 namespace esphome {
 namespace opentherm {

--- a/components/opentherm/HardwareSerial.cpp
+++ b/components/opentherm/HardwareSerial.cpp
@@ -25,7 +25,9 @@ void HardwareSerial::begin(uint32_t baudRate, uint32_t tx, uint32_t rx) {
 #if CONFIG_UART_ISR_IN_IRAM
   intr_alloc_flags = ESP_INTR_FLAG_IRAM;
 #endif
-
+  //workaround due to https://github.com/espressif/esp-idf/issues/17459
+  ESP_ERROR_CHECK(gpio_reset_pin(rx));
+  // to be removed after upstream is corrected
   ESP_ERROR_CHECK(uart_driver_install(ECHO_UART_PORT_NUM, BUF_SIZE * 2, 0, 0, NULL, intr_alloc_flags));
   ESP_ERROR_CHECK(uart_param_config(ECHO_UART_PORT_NUM, &uart_config));
   ESP_ERROR_CHECK(uart_set_pin(ECHO_UART_PORT_NUM, rx, tx, -1, -1));

--- a/components/opentherm/HardwareSerial.cpp
+++ b/components/opentherm/HardwareSerial.cpp
@@ -4,7 +4,7 @@
 
 #include "HardwareSerial.h"
 
-#define ECHO_UART_PORT_NUM (1)
+#define ECHO_UART_PORT_NUM (uart_port_t)(1)
 
 namespace esphome {
 namespace opentherm {

--- a/components/opentherm/HardwareSerial.cpp
+++ b/components/opentherm/HardwareSerial.cpp
@@ -1,4 +1,5 @@
 #include "driver/uart.h"
+#include "driver/gpio.h"
 #include "esp_err.h"
 #include "esp_log.h"
 

--- a/components/opentherm/HardwareSerial.cpp
+++ b/components/opentherm/HardwareSerial.cpp
@@ -28,6 +28,7 @@ void HardwareSerial::begin(uint32_t baudRate, uint32_t tx, uint32_t rx) {
 #endif
   //workaround due to https://github.com/espressif/esp-idf/issues/17459
   ESP_ERROR_CHECK(gpio_reset_pin((gpio_num_t )rx));
+  ESP_ERROR_CHECK(gpio_reset_pin((gpio_num_t )tx));
   // to be removed after upstream is corrected
   ESP_ERROR_CHECK(uart_driver_install(ECHO_UART_PORT_NUM, BUF_SIZE * 2, 0, 0, NULL, intr_alloc_flags));
   ESP_ERROR_CHECK(uart_param_config(ECHO_UART_PORT_NUM, &uart_config));

--- a/components/opentherm/HardwareSerial.cpp
+++ b/components/opentherm/HardwareSerial.cpp
@@ -27,7 +27,7 @@ void HardwareSerial::begin(uint32_t baudRate, uint32_t tx, uint32_t rx) {
   intr_alloc_flags = ESP_INTR_FLAG_IRAM;
 #endif
   //workaround due to https://github.com/espressif/esp-idf/issues/17459
-  ESP_ERROR_CHECK(gpio_reset_pin(rx));
+  ESP_ERROR_CHECK(gpio_reset_pin((gpio_num_t )rx));
   // to be removed after upstream is corrected
   ESP_ERROR_CHECK(uart_driver_install(ECHO_UART_PORT_NUM, BUF_SIZE * 2, 0, 0, NULL, intr_alloc_flags));
   ESP_ERROR_CHECK(uart_param_config(ECHO_UART_PORT_NUM, &uart_config));

--- a/components/opentherm/binary_sensor/__init__.py
+++ b/components/opentherm/binary_sensor/__init__.py
@@ -10,11 +10,8 @@ COMPONENT_TYPE = const.BINARY_SENSOR
 
 def get_entity_validation_schema(entity: schema.BinarySensorSchema) -> cv.Schema:
     return binary_sensor.binary_sensor_schema(
-        device_class=(
-            entity.device_class
-            or binary_sensor._UNDEF  # pylint: disable=protected-access
-        ),
-        icon=(entity.icon or binary_sensor._UNDEF),  # pylint: disable=protected-access
+        device_class=(entity.device_class or cv.UNDEFINED),
+        icon=(entity.icon or cv.UNDEFINED),
     )
 
 

--- a/components/opentherm/generate.py
+++ b/components/opentherm/generate.py
@@ -1,5 +1,5 @@
-from collections.abc import Awaitable
-from typing import Any, Callable, Optional
+from collections.abc import Awaitable, Callable
+from typing import Any
 
 import esphome.codegen as cg
 from esphome.const import CONF_ID
@@ -102,7 +102,7 @@ def define_setting_readers(component_type: str, keys: list[str]) -> None:
 
 
 def add_messages(hub: cg.MockObj, keys: list[str], schemas: dict[str, TSchema]):
-    messages: dict[str, tuple[bool, Optional[int]]] = {}
+    messages: dict[str, tuple[bool, int | None]] = {}
     for key in keys:
         messages[schemas[key].message] = (
             schemas[key].keep_updated,

--- a/components/opentherm/number/__init__.py
+++ b/components/opentherm/number/__init__.py
@@ -35,7 +35,7 @@ async def new_openthermnumber(config: dict[str, Any]) -> cg.Pvariable:
 
 def get_entity_validation_schema(entity: schema.InputSchema) -> cv.Schema:
     return (
-        number.number_schema(Add commentMore actions
+        number.number_schema(
             OpenthermNumber, unit_of_measurement=entity.unit_of_measurement
         )
         .extend(

--- a/components/opentherm/number/__init__.py
+++ b/components/opentherm/number/__init__.py
@@ -3,13 +3,8 @@ from typing import Any
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import number
-from esphome.const import (
-    CONF_ID,
-    CONF_UNIT_OF_MEASUREMENT,
-    CONF_STEP,
-    CONF_INITIAL_VALUE,
-    CONF_RESTORE_VALUE,
-)
+from esphome.const import CONF_INITIAL_VALUE, CONF_RESTORE_VALUE, CONF_STEP
+
 from .. import const, schema, validate, input, generate
 
 DEPENDENCIES = [const.OPENTHERM]
@@ -21,33 +16,30 @@ OpenthermNumber = generate.opentherm_ns.class_(
 
 
 async def new_openthermnumber(config: dict[str, Any]) -> cg.Pvariable:
-    var = cg.new_Pvariable(config[CONF_ID])
-    await cg.register_component(var, config)
-    await number.register_number(
-        var,
+    var = await number.new_number(
         config,
         min_value=config[input.CONF_min_value],
         max_value=config[input.CONF_max_value],
         step=config[input.CONF_step],
     )
+    await cg.register_component(var, config)
     input.generate_setters(var, config)
 
-    if CONF_INITIAL_VALUE in config:
-        cg.add(var.set_initial_value(config[CONF_INITIAL_VALUE]))
-    if CONF_RESTORE_VALUE in config:
-        cg.add(var.set_restore_value(config[CONF_RESTORE_VALUE]))
+    if (initial_value := config.get(CONF_INITIAL_VALUE, None)) is not None:
+        cg.add(var.set_initial_value(initial_value))
+    if (restore_value := config.get(CONF_RESTORE_VALUE, None)) is not None:
+        cg.add(var.set_restore_value(restore_value))
 
     return var
 
 
 def get_entity_validation_schema(entity: schema.InputSchema) -> cv.Schema:
     return (
-        number.NUMBER_SCHEMA.extend(
+        number.number_schema(Add commentMore actions
+            OpenthermNumber, unit_of_measurement=entity.unit_of_measurement
+        )
+        .extend(
             {
-                cv.GenerateID(): cv.declare_id(OpenthermNumber),
-                cv.Optional(
-                    CONF_UNIT_OF_MEASUREMENT, entity.unit_of_measurement
-                ): cv.string_strict,
                 cv.Optional(CONF_STEP, entity.step): cv.float_,
                 cv.Optional(CONF_INITIAL_VALUE): cv.float_,
                 cv.Optional(CONF_RESTORE_VALUE): cv.boolean,

--- a/components/opentherm/output/output.cpp
+++ b/components/opentherm/output/output.cpp
@@ -10,7 +10,7 @@ void opentherm::OpenthermOutput::write_state(float state) {
   ESP_LOGD(TAG, "Received state: %.2f. Min value: %.2f, max value: %.2f", state, min_value_, max_value_);
   this->state = state < 0.003 && this->zero_means_zero_
                     ? 0.0
-                    : clamp(lerp(state, min_value_, max_value_), min_value_, max_value_);
+                     : clamp(std::lerp(min_value_, max_value_, state), min_value_, max_value_);
   this->has_state_ = true;
   ESP_LOGD(TAG, "Output %s set to %.2f", this->id_, this->state);
 }

--- a/components/opentherm/schema.py
+++ b/components/opentherm/schema.py
@@ -2,7 +2,7 @@
 # inputs of the OpenTherm component.
 
 from dataclasses import dataclass
-from typing import Optional, TypeVar, Any
+from typing import Any, TypeVar
 
 import esphome.config_validation as cv
 from esphome.const import (
@@ -61,11 +61,11 @@ TSchema = TypeVar("TSchema", bound=EntitySchema)
 class SensorSchema(EntitySchema):
     accuracy_decimals: int
     state_class: str
-    unit_of_measurement: Optional[str] = None
-    icon: Optional[str] = None
-    device_class: Optional[str] = None
+    unit_of_measurement: str | None = None
+    icon: str | None = None
+    device_class: str | None = None
     disabled_by_default: bool = False
-    order: Optional[int] = None
+    order: int | None = None
 
 
 SENSORS: dict[str, SensorSchema] = {
@@ -461,9 +461,9 @@ SENSORS: dict[str, SensorSchema] = {
 
 @dataclass
 class BinarySensorSchema(EntitySchema):
-    icon: Optional[str] = None
-    device_class: Optional[str] = None
-    order: Optional[int] = None
+    icon: str | None = None
+    device_class: str | None = None
+    order: int | None = None
 
 
 BINARY_SENSORS: dict[str, BinarySensorSchema] = {
@@ -654,7 +654,7 @@ BINARY_SENSORS: dict[str, BinarySensorSchema] = {
 
 @dataclass
 class SwitchSchema(EntitySchema):
-    default_mode: Optional[str] = None
+    default_mode: str | None = None
 
 
 SWITCHES: dict[str, SwitchSchema] = {
@@ -721,9 +721,9 @@ class InputSchema(EntitySchema):
     unit_of_measurement: str
     step: float
     range: tuple[int, int]
-    icon: Optional[str] = None
-    auto_max_value: Optional[AutoConfigure] = None
-    auto_min_value: Optional[AutoConfigure] = None
+    icon: str | None = None
+    auto_max_value: AutoConfigure | None = None
+    auto_min_value: AutoConfigure | None = None
 
 
 INPUTS: dict[str, InputSchema] = {
@@ -834,7 +834,7 @@ class SettingSchema(EntitySchema):
     backing_type: str
     validation_schema: cv.Schema
     default_value: Any
-    order: Optional[int] = None
+    order: int | None = None
 
 
 SETTINGS: dict[str, SettingSchema] = {

--- a/components/opentherm/sensor/__init__.py
+++ b/components/opentherm/sensor/__init__.py
@@ -22,12 +22,10 @@ MSG_DATA_TYPES = {
 
 def get_entity_validation_schema(entity: schema.SensorSchema) -> cv.Schema:
     return sensor.sensor_schema(
-        unit_of_measurement=entity.unit_of_measurement
-        or sensor._UNDEF,  # pylint: disable=protected-access
+        unit_of_measurement=entity.unit_of_measurement or cv.UNDEFINED,  # pylint: disable=protected-access
         accuracy_decimals=entity.accuracy_decimals,
-        device_class=entity.device_class
-        or sensor._UNDEF,  # pylint: disable=protected-access
-        icon=entity.icon or sensor._UNDEF,  # pylint: disable=protected-access
+        device_class=entity.device_class or cv.UNDEFINED,  # pylint: disable=protected-access
+        icon=entity.icon or cv.UNDEFINED,  # pylint: disable=protected-access
         state_class=entity.state_class,
     ).extend(
         {

--- a/components/opentherm/switch/__init__.py
+++ b/components/opentherm/switch/__init__.py
@@ -3,7 +3,6 @@ from typing import Any
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import switch
-from esphome.const import CONF_ID
 from .. import const, schema, validate, generate
 
 DEPENDENCIES = [const.OPENTHERM]
@@ -15,15 +14,14 @@ OpenthermSwitch = generate.opentherm_ns.class_(
 
 
 async def new_openthermswitch(config: dict[str, Any]) -> cg.Pvariable:
-    var = cg.new_Pvariable(config[CONF_ID])
+    var = await switch.new_switch(config)
     await cg.register_component(var, config)
-    await switch.register_switch(var, config)
     return var
 
 
 def get_entity_validation_schema(entity: schema.SwitchSchema) -> cv.Schema:
-    return switch.SWITCH_SCHEMA.extend(
-        {cv.GenerateID(): cv.declare_id(OpenthermSwitch)}
+    return switch.switch_schema(
+        OpenthermSwitch, default_restore_mode=entity.default_mode
     ).extend(cv.COMPONENT_SCHEMA)
 
 

--- a/components/opentherm/validate.py
+++ b/components/opentherm/validate.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from collections.abc import Callable
 
 from voluptuous import Schema
 


### PR DESCRIPTION
This pull request is fixing the same issue as the other pending pull request #3, but this one is copying the 'official' updates applied on the origninal esphome opentherm library:
 [esphome #8725](https://github.com/esphome/esphome/pull/8725)
 [esphome #8756](https://github.com/esphome/esphome/pull/8756)
