### PR TITLE
Fix ESPHome 2025.8.0 compatibility

### DIFF
--- a/components/opentherm/HardwareSerial.cpp
+++ b/components/opentherm/HardwareSerial.cpp
@@ -4,7 +4,7 @@
 
 #include "HardwareSerial.h"
 
-#define ECHO_UART_PORT_NUM (1)
+#define ECHO_UART_PORT_NUM (uart_port_t(1))
 
 namespace esphome {
 namespace opentherm {

--- a/components/opentherm/binary_sensor/__init__.py
+++ b/components/opentherm/binary_sensor/__init__.py
@@ -12,9 +12,9 @@ def get_entity_validation_schema(entity: schema.BinarySensorSchema) -> cv.Schema
     return binary_sensor.binary_sensor_schema(
         device_class=(
             entity.device_class
-            or binary_sensor._UNDEF  # pylint: disable=protected-access
+            or cv.UNDEFINED
         ),
-        icon=(entity.icon or binary_sensor._UNDEF),  # pylint: disable=protected-access
+        icon=(entity.icon or cv.UNDEFINED),
     )
 
 

--- a/components/opentherm/output/output.cpp
+++ b/components/opentherm/output/output.cpp
@@ -1,5 +1,6 @@
-#include "esphome/core/helpers.h"  // for clamp() and lerp()
+#include "esphome/core/helpers.h"  // for clamp()
 #include "output.h"
+#include <cmath>  // for std::lerp
 
 namespace esphome {
 namespace opentherm {
@@ -10,7 +11,7 @@ void opentherm::OpenthermOutput::write_state(float state) {
   ESP_LOGD(TAG, "Received state: %.2f. Min value: %.2f, max value: %.2f", state, min_value_, max_value_);
   this->state = state < 0.003 && this->zero_means_zero_
                     ? 0.0
-                    : clamp(lerp(state, min_value_, max_value_), min_value_, max_value_);
+                    : clamp(std::lerp(min_value_, max_value_, state), min_value_, max_value_);
   this->has_state_ = true;
   ESP_LOGD(TAG, "Output %s set to %.2f", this->id_, this->state);
 }

--- a/components/opentherm/sensor/__init__.py
+++ b/components/opentherm/sensor/__init__.py
@@ -23,11 +23,11 @@ MSG_DATA_TYPES = {
 def get_entity_validation_schema(entity: schema.SensorSchema) -> cv.Schema:
     return sensor.sensor_schema(
         unit_of_measurement=entity.unit_of_measurement
-        or sensor._UNDEF,  # pylint: disable=protected-access
+        or cv.UNDEFINED,
         accuracy_decimals=entity.accuracy_decimals,
         device_class=entity.device_class
-        or sensor._UNDEF,  # pylint: disable=protected-access
-        icon=entity.icon or sensor._UNDEF,  # pylint: disable=protected-access
+        or cv.UNDEFINED,
+        icon=entity.icon or cv.UNDEFINED,
         state_class=entity.state_class,
     ).extend(
         {


### PR DESCRIPTION
- Replace binary_sensor._UNDEF and sensor._UNDEF with cv.UNDEFINED
- Fix UART port type casting for ESP-IDF compatibility
- Replace deprecated lerp() with std::lerp() with correct argument order

These changes make the component compatible with ESPHome 2025.8.0 and later versions.